### PR TITLE
Adding the ability to treat a job as a test

### DIFF
--- a/zencoder/core.py
+++ b/zencoder/core.py
@@ -237,9 +237,7 @@ class Job(HTTPBackend):
         @param outputs: a list of output dictionaries
         @param options: a dictionary of job options
         """
-        as_test = 0
-        if (self.test):
-          as_test = 1
+        as_test = int(self.test)
 
         data = {"api_key": self.api_key, "input": input, "test": as_test}
         if outputs:


### PR DESCRIPTION
Passing in the test argument when instantiating an instance of Zencoder will have all jobs created to contain the test flag. Defaults to false.

zen = Zencoder(apiKey, test=True)
